### PR TITLE
Add space-efficient encoder for Onion and I2P addresses

### DIFF
--- a/src/darkseed/dns/custom_encoder.py
+++ b/src/darkseed/dns/custom_encoder.py
@@ -1,0 +1,103 @@
+"""Module for custom Darknet address encoding."""
+
+import logging as log
+from dataclasses import dataclass
+from typing import ClassVar
+
+import dns.rdata
+import dns.rrset
+from dns.rdataclass import IN
+from dns.rdatatype import NULL as NULL_TYPE
+
+from darkseed.node import (Address, AddressCodec, I2PAddressCodec,
+                           OnionAddressCodec)
+
+
+@dataclass
+class MultiAddressCodecRecord:
+    """Class representing a record used in the MultiAddressCodec."""
+
+    type: int
+    data: bytes
+    _address: str
+
+    def __str__(self):
+        """Include original address in string representations."""
+        return f"Record(type={self.type}, data={self.data.hex()}) was={self._address}"
+
+    ONION_V3_ADDR: ClassVar[int] = 0
+    I2P_ADDR: ClassVar[int] = 1 << 0
+    RECORD_LEN: ClassVar[int] = 1 + 32  # 1-byte type + 32-byte data
+
+    def to_wire(self) -> bytes:
+        """Convert into wire format (bytes)."""
+        return self.type.to_bytes(1, "big") + self.data
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "MultiAddressCodecRecord":
+        """Create a MultiAddressCodecRecord instance from bytes."""
+        if len(data) != MultiAddressCodecRecord.RECORD_LEN:
+            raise ValueError(f"Invalid record length: {len(data)}")
+        record_type = int.from_bytes([data[0]])
+        if record_type not in (cls.ONION_V3_ADDR, cls.I2P_ADDR):
+            raise ValueError(f"Invalid record type: {record_type}")
+        record_data = data[1:]
+        if record_type == cls.ONION_V3_ADDR:
+            # TODO
+            # Address class that instantiates appropriate subclasses would be
+            # better! Address.to_pubkey(), to_binary(), to_base64(), etc.;
+            # maybe make it Address.from_str() Address.from_bytes() as well!
+            address = OnionAddressCodec.pubkey_to_address(record_data)
+            return cls(record_type, record_data, address)
+        if record_type == cls.I2P_ADDR:
+            address = I2PAddressCodec.hash_to_address(record_data)
+            return cls(record_type, record_data, address)
+        raise ValueError(f"Invalid record type: {record_type}")
+
+    @classmethod
+    def from_address(cls, address: Address) -> "MultiAddressCodecRecord":
+        """Create a MultiAddressCodecRecord instance from an Address."""
+        record_type = MultiAddressCodecRecord.address_to_type(address)
+        record_data = AddressCodec.encode_address(address, encoding="raw")
+        assert isinstance(record_data, bytes), "Expected data to be bytes"
+        return cls(record_type, record_data, address.address)
+
+    @staticmethod
+    def address_to_type(address: Address) -> int:
+        """Detremine record type for address."""
+        if address.onion:
+            return MultiAddressCodecRecord.ONION_V3_ADDR
+        if address.i2p:
+            return MultiAddressCodecRecord.I2P_ADDR
+        raise ValueError(f"Unsupported address type: {address}")
+
+
+class MultiAddressCodec:
+    """
+    Class for encoding and decoding multiple addresses in a single DNS NULL
+    record using a custom binary format:
+
+    <num_records> <record_1> ... <record_n>,
+    where an individual <record> comprises:
+        <type>: onion or i2p; and
+        <data>: 256-bit pubkey or hash
+    """
+
+    @staticmethod
+    def build_record(
+        addresses: list[Address],
+        domain: str = "seed.21.ninja.",
+        ttl: int = 60,
+    ) -> dns.rrset.RRset:
+        """Encode multiple addresses into a single DNS NULL record."""
+        num_records = len(addresses)
+        assert 0 < num_records < 256, f"Invalid number of records: {num_records}"
+        rdata = num_records.to_bytes(1, "big")
+        log.debug("num_records=%d, rdata=%s", num_records, rdata.hex())
+        for address in addresses:
+            record = MultiAddressCodecRecord.from_address(address)
+            rdata += record.to_wire()
+            log.debug("Added new record %s, rdata=%s", record, rdata.hex())
+        rdata = dns.rdata.from_wire(IN, NULL_TYPE, rdata, 0, len(rdata))
+        record = dns.rrset.from_rdata(domain, ttl, rdata)
+        return record

--- a/src/darkseed/dns/record_builder.py
+++ b/src/darkseed/dns/record_builder.py
@@ -6,35 +6,34 @@ import dns.rdata
 import dns.rrset
 from dns.rdataclass import IN
 from dns.rdatatype import AAAA as AAAA_TYPE
-from dns.rdatatype import NULL as NULL_TYPE
-from dns.rdatatype import TXT as TXT_TYPE
 from dns.rdatatype import A as A_TYPE
-from dns.rdtypes.ANY.TXT import TXT
 from dns.rdtypes.IN.A import A
 from dns.rdtypes.IN.AAAA import AAAA
 
-from darkseed.node import Address, AddressCodec
+from darkseed.node import Address
 
-# todos:
-# - avoid dups
-# - inbue with domain knowledge (e.g., if CJDNS, I2P, and TOR records exist,
-#   provide at least one of the two former, two of the latter)
+
+def address_type_checker(func):
+    """Decorator to check if the address has a valid type before proceeding."""
+
+    def wrapper(self, address, *args, **kwargs):
+        if not (address.ipv4 or address.ipv6 or address.cjdns):
+            raise ValueError("Unsupported address type!")
+        return func(self, address, *args, **kwargs)
+
+    return wrapper
 
 
 class RecordBuilder:
     """Class for building DNS resource records."""
 
+    @address_type_checker
     @staticmethod
     def build_record(
-        address: Address,
-        encoding: str = "address",
-        domain: str = "seed.21.ninja.",
-        ttl: int = 60,
+        address: Address, domain: str = "seed.21.ninja.", ttl: int = 60
     ) -> dns.rrset.RRset:
         """Build a DNS record for a node using the specified encoding."""
-
-        rdata = RecordBuilder.get_rdata(address, encoding)
-
+        rdata = RecordBuilder.get_rdata(address)
         record = dns.rrset.from_rdata(domain, ttl, rdata)
 
         log.debug(
@@ -45,29 +44,11 @@ class RecordBuilder:
         )
         return record
 
+    @address_type_checker
     @staticmethod
-    def get_rdata(address: Address, encoding: str = "address") -> dns.rdata.Rdata:
-        """
-        Get DNS resource record data.
-
-        Always use 'address' encoding for IPv4, IPv6, and CJDNS addresses.
-        """
-        if encoding != "address" and (address.ipv4 or address.ipv6 or address.cjdns):
-            log.warning(
-                "Encoding '%s' not supported for %s. Defaulting to 'address' encoding!",
-                encoding,
-                address.net_type,
-            )
-
+    def get_rdata(address: Address) -> dns.rdata.Rdata:
+        """Get DNS resource record data."""
         if address.ipv4:
             return A(IN, A_TYPE, address.address)
-        if address.ipv6 or address.cjdns:
-            return AAAA(IN, AAAA_TYPE, address.address)
-        if encoding == "address" and (address.onion or address.i2p):
-            return TXT(IN, TXT_TYPE, [address.address])
-
-        data = AddressCodec.encode_address(address, encoding)
-        assert isinstance(data, (str, bytes)), "Invalid data type for encoding!"
-        if isinstance(data, str):
-            return TXT(IN, TXT_TYPE, [data])
-        return dns.rdata.from_wire(IN, NULL_TYPE, data, 0, len(data))
+        # ipv6 or cjdns
+        return AAAA(IN, AAAA_TYPE, address.address)

--- a/src/darkseed/node/__init__.py
+++ b/src/darkseed/node/__init__.py
@@ -1,9 +1,18 @@
 """Import appropriate classes from address and address_codec files into module."""
 
 from .address import Address
-from .address_codecs import AddressCodec
+from .address_codecs import AddressCodec, I2PAddressCodec, OnionAddressCodec
 from .network import DarknetSpecs, NetworkType
 from .node import Node
 from .services import Services
 
-__all__ = ["Address", "AddressCodec", "DarknetSpecs", "NetworkType", "Node", "Services"]
+__all__ = [
+    "Address",
+    "AddressCodec",
+    "DarknetSpecs",
+    "NetworkType",
+    "Node",
+    "Services",
+    "I2PAddressCodec",
+    "OnionAddressCodec",
+]


### PR DESCRIPTION
Encoder extracts minimum binary data required to reconstruct addresses from Onion and I2P addresses, and encodes multiple addresses in a single DNS NULL record in binary format:
`<num_records> <record_1> ... <record_n>`, where
`<record> = <record_type> <record_data>`, where `<record_type>` is 0 for onion, 1 for i2p; and `<record_data>` is a 256-bit pubkey for onion and a 256-bit hash for I2P.

Todo:
- [x] Implement
- [x] Working prototype
- [x] Remove binary encoding from `RecordBuilder` (previously used for individual NULL records)
- [x] Refactor DNSResponder