### PR TITLE
Refactor and support DNS via TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # darkseed
 
-A DNS seeder for Bitcoin supporting all network types.
+A Bitcoin DNS seed prototype, supporting all network types and publishing results via
+DNS (UDP and TCP) and REST.
 
 ## Components
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "darkseed"
-version = "0.1.0"
+version = "0.2.0"
 description = "Bitcoin DNS seeder with support for all network types"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "AGPLv3"

--- a/src/darkseed/daemon.py
+++ b/src/darkseed/daemon.py
@@ -8,7 +8,7 @@ import time
 
 from darkseed.config import get_config
 from darkseed.dns import DNSServer
-from darkseed.node_loader import NodeLoader
+from darkseed.node_manager import NodeManager
 from darkseed.rest import RESTServer
 
 
@@ -48,16 +48,14 @@ def main():
     command_thread = threading.Thread(target=start_command_server)
     command_thread.start()
 
-    dns_server = DNSServer(address=conf.dns_address, port=conf.dns_port)
+    node_manager = NodeManager(conf.crawler_path)
+    node_manager.start()
+
+    dns_server = DNSServer(conf.dns_address, conf.dns_port, node_manager)
     dns_server.start()
 
-    rest_server = RESTServer(conf.rest_address, conf.rest_port)
+    rest_server = RESTServer(conf.rest_address, conf.rest_port, node_manager)
     rest_server.start()
-
-    dns_updater = dns_server.get_update_function()
-    rest_updater = rest_server.get_update_function()
-    node_provider = NodeLoader(conf.crawler_path, dns_updater, rest_updater)
-    node_provider.start()
 
 
 if __name__ == "__main__":

--- a/src/darkseed/dns/__init__.py
+++ b/src/darkseed/dns/__init__.py
@@ -2,11 +2,10 @@
 
 from .custom_encoder import CustomNullEncoding
 from .record_builder import RecordBuilder
-from .server import DNSResponder, DNSServer
+from .server import DNSServer
 
 __all__ = [
     "RecordBuilder",
-    "DNSResponder",
     "DNSServer",
     "CustomNullEncoding",
 ]

--- a/src/darkseed/rest/server.py
+++ b/src/darkseed/rest/server.py
@@ -1,20 +1,23 @@
 """REST API server for Darkseed."""
 
 import logging as log
-import random
 from threading import Thread
 
 from flask import Flask, jsonify
+
+from darkseed.node import NetworkType
+from darkseed.node_manager import NodeManager
 
 
 class RESTServer:
     """REST API server for Darkseed."""
 
-    def __init__(self, address: str, port: int):
+    def __init__(self, address: str, port: int, node_manager: NodeManager):
         self.app = Flask(__name__)
         self.reachable_nodes = []
         self.address = address
         self.port = port
+        self.node_manager = node_manager
         self.server_thread = None
         self.setup_routes()
 
@@ -24,52 +27,42 @@ class RESTServer:
         @self.app.route("/nodes", methods=["GET"])
         def get_nodes():
             """Get reachable nodes of different network types."""
-            return self._get_nodes_response()
+            addresses = self.node_manager.get_random_addresses(NetworkType.IPV4, 7)
+            addresses += self.node_manager.get_random_addresses(NetworkType.IPV6, 7)
+            addresses += self.node_manager.get_random_addresses(NetworkType.ONION_V3, 6)
+            addresses += self.node_manager.get_random_addresses(NetworkType.I2P, 6)
+            addresses += self.node_manager.get_random_addresses(NetworkType.CJDNS, 6)
+            return jsonify(addresses), 200
 
         @self.app.route("/nodes/ipv4", methods=["GET"])
         def get_ipv4_nodes():
             """Get reachable IPv4 nodes."""
-            return self._get_nodes_response(node_type="ipv4")
+            addresses = self.node_manager.get_random_addresses(NetworkType.IPV4, 32)
+            return jsonify(addresses), 200
 
         @self.app.route("/nodes/ipv6", methods=["GET"])
         def get_ipv6_nodes():
             """Get reachable IPv6 nodes."""
-            return self._get_nodes_response(node_type="ipv6")
+            addresses = self.node_manager.get_random_addresses(NetworkType.IPV6, 32)
+            return jsonify(addresses), 200
 
         @self.app.route("/nodes/onion", methods=["GET"])
         def get_onion_nodes():
             """Get reachable Onion nodes."""
-            return self._get_nodes_response(node_type="onion")
+            addresses = self.node_manager.get_random_addresses(NetworkType.ONION_V3, 32)
+            return jsonify(addresses), 200
 
         @self.app.route("/nodes/i2p", methods=["GET"])
         def get_i2p_nodes():
             """Get reachable I2P nodes."""
-            return self._get_nodes_response(node_type="i2p")
+            addresses = self.node_manager.get_random_addresses(NetworkType.I2P, 32)
+            return jsonify(addresses), 200
 
         @self.app.route("/nodes/cjdns", methods=["GET"])
         def get_cjdns_nodes():
             """Get reachable CJDNS nodes."""
-            return self._get_nodes_response(node_type="cjdns")
-
-    def _get_nodes_response(self, node_type=None, num_requested=32):
-        """Select a specific number of address based on address type."""
-        if not self.reachable_nodes:
-            return jsonify({"error": "No reachable nodes available"}), 500
-
-        addresses = [n.address for n in self.reachable_nodes]
-        if node_type:
-            addresses = [a for a in addresses if getattr(a, node_type)]
-        num_available = len(addresses)
-        num_addresses = min(num_requested, num_available)
-        if num_addresses < num_requested:
-            log.warning(
-                "Insufficient addresses (requested=%d, available=%d): returning %d.",
-                num_requested,
-                num_available,
-                num_addresses,
-            )
-        addresses = random.sample(addresses, num_addresses)
-        return jsonify(addresses), 200
+            addresses = self.node_manager.get_random_addresses(NetworkType.CJDNS, 32)
+            return jsonify(addresses), 200
 
     def start(self):
         """Start REST server thread."""
@@ -78,20 +71,3 @@ class RESTServer:
         )
         self.server_thread.start()
         log.info("Started RESTServer on %s:%d.", self.address, self.port)
-
-    def set_reachable_nodes(self, nodes):
-        """Set reachable nodes."""
-        self.reachable_nodes = nodes
-        log.info(
-            "Updated reachable node pool for RESTServer: total=%d, ipv4=%d, ipv6=%d, onion_v3=%d, i2p=%d, cjdns=%d",
-            len(nodes),
-            len([n for n in nodes if n.address.ipv4]),
-            len([n for n in nodes if n.address.ipv6]),
-            len([n for n in nodes if n.address.onion]),
-            len([n for n in nodes if n.address.i2p]),
-            len([n for n in nodes if n.address.cjdns]),
-        )
-
-    def get_update_function(self):
-        """Return the set_reachable_nodes function of the DNSResponder."""
-        return self.set_reachable_nodes


### PR DESCRIPTION
Refactor:
- [x] Deduplicate and move node selection code from DNS and REST into what is now called NodeManager(previously NodeLoader)
  - [x] DNS
  - [x] REST
- [x] Use Singleton Pattern to pass NodeManager to DNS and REST servers
  - [x] DNS
  - [x] REST
- [x] Simplify DNS server code (static functions, simplify various parts)
- [x] Add TCP functionality for DNS server
- [x] Bump version, update CHANGELOG and README