### PR TITLE
Restrict replies to authoritative records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2024-09-03
+
+- Respect DNS zone
+  - Add `--dns-zone` command-line argument and `darkseed.dns.zone` nix module setting
+  - Refuse DNS queries that don't match configured zone
+  - Use dedicated `DNSConfig` class in `config.py`
+- Remove unused `CommandServer`
+- Introduce [change log](CHANGELOG.md)

--- a/module.nix
+++ b/module.nix
@@ -42,6 +42,12 @@ in
         example = "192.168.0.1";
         description = mdDoc "Address used by DNS server.";
       };
+      zone = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "dnsseed.acme.com.";
+        description = mdDoc "Zone managed by DNS server.";
+      };
     };
 
     rest = {
@@ -65,6 +71,7 @@ in
   config = mkIf cfg.enable {
     assertions = [
       { assertion = !(cfg.cjdns.enable && cfg.cjdns.address == null); message = "services.darkseed.cjdns.address must be set when services.darkseed.cjdns.enable is true."; }
+      { assertion = cfg.dns.zone != null; message = "services.darkseed.dns.zone must be set."; }
     ];
 
     networking.firewall = {
@@ -120,6 +127,7 @@ in
             --log-level ${cfg.logLevel} \
             --dns-port ${toString cfg.dns.port} \
             --dns-address ${cfg.dns.address} \
+            --dns-zone ${cfg.dns.zone} \
             --rest-port ${toString cfg.rest.port} \
             --rest-address ${cfg.rest.address} \
           '';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "darkseed"
-version = "0.2.0"
+version = "0.3.0"
 description = "Bitcoin DNS seeder with support for all network types"
 authors = ["virtu <virtu@cryptic.to>"]
 license = "AGPLv3"

--- a/src/darkseed/config.py
+++ b/src/darkseed/config.py
@@ -10,6 +10,24 @@ from pathlib import Path
 __version__ = importlib.metadata.version(__package__ or __name__)
 
 
+@dataclass(frozen=True)
+class DNSConfig:
+    """DNS Server configuration."""
+
+    address: str
+    port: int
+    zone: str
+
+    @classmethod
+    def parse(cls, args):
+        """Create class instance from arguments."""
+        zone = args.dns_zone.lower()
+        if not zone.endswith("."):
+            zone += "."
+            print(f"Warning: Appended missing final dot to DNS zone: {zone}")
+        return cls(address=args.dns_address, port=args.dns_port, zone=zone)
+
+
 @dataclass
 class Config:
     """Configuration settings for the daemon."""
@@ -17,8 +35,7 @@ class Config:
     version: str
     timestamp: datetime.datetime
     log_level: str
-    dns_address: str
-    dns_port: int
+    dns: DNSConfig
     rest_address: str
     rest_port: int
     crawler_path: Path
@@ -32,8 +49,7 @@ class Config:
             version=__version__,
             timestamp=args.timestamp,
             log_level=args.log_level.upper(),
-            dns_address=args.dns_address,
-            dns_port=args.dns_port,
+            dns=DNSConfig.parse(args),
             rest_address=args.rest_address,
             rest_port=args.rest_port,
             crawler_path=args.crawler_path,
@@ -83,6 +99,13 @@ def parse_args():
         type=int,
         default=53,
         help="UDP port used by the DNS server",
+    )
+
+    parser.add_argument(
+        "--dns-zone",
+        type=str,
+        required=True,
+        help="Domain name for the DNS zone (e.g., dnsseed.acme.com.)",
     )
 
     parser.add_argument(

--- a/src/darkseed/daemon.py
+++ b/src/darkseed/daemon.py
@@ -1,36 +1,12 @@
 """Darkseed daemon that listens for DNS requests and commands."""
 
 import logging as log
-import socketserver
-import sys
-import threading
 import time
 
 from darkseed.config import get_config
 from darkseed.dns import DNSServer
 from darkseed.node_manager import NodeManager
 from darkseed.rest import RESTServer
-
-
-class CommandServerHandler(socketserver.BaseRequestHandler):
-    def handle(self):
-        data = self.request.recv(1024).strip().decode("utf-8")
-        log.debug("Command received: %s", data)
-        response = ""
-        if data.lower() == "status":
-            response = "Server running. Uptime: 100 minutes."
-        elif data.lower() == "update":
-            response = "Updated records."
-        else:
-            response = "Invalid command."
-
-        self.request.sendall(response.encode("utf-8"))
-
-
-def start_command_server():
-    server = socketserver.TCPServer(("localhost", 8054), CommandServerHandler)
-    log.info("Started CommandServer thread.")
-    server.serve_forever()
 
 
 def main():
@@ -45,13 +21,10 @@ def main():
     log.Formatter.converter = time.gmtime
     log.info("Using configuration: %s", conf)
 
-    command_thread = threading.Thread(target=start_command_server)
-    command_thread.start()
-
     node_manager = NodeManager(conf.crawler_path)
     node_manager.start()
 
-    dns_server = DNSServer(conf.dns_address, conf.dns_port, node_manager)
+    dns_server = DNSServer(conf.dns, node_manager)
     dns_server.start()
 
     rest_server = RESTServer(conf.rest_address, conf.rest_port, node_manager)

--- a/src/darkseed/dns/server.py
+++ b/src/darkseed/dns/server.py
@@ -4,13 +4,15 @@ import logging as log
 import socketserver
 import threading
 from dataclasses import dataclass
-from typing import ClassVar, List
+from typing import Callable, ClassVar, List
 
 import dns.message
+import dns.rcode
 import dns.rdataclass
 import dns.rdatatype
 import dns.rrset
 
+from darkseed.config import DNSConfig
 from darkseed.node import Address, NetworkType
 from darkseed.node_manager import NodeManager
 
@@ -34,6 +36,7 @@ class DNSHandler:
     """
 
     _NODE_MANAGER: ClassVar[NodeManager]
+    _ZONE: ClassVar[str]
     RDTYPE_TO_NETCOUNT: ClassVar[
         dict[dns.rdatatype.RdataType, dict[NetworkType, int]]
     ] = {
@@ -59,30 +62,45 @@ class DNSHandler:
         cls._NODE_MANAGER = node_manager
 
     @classmethod
+    def set_zone(cls, zone: str):
+        """Set the zone manager."""
+        cls._ZONE = zone
+
+    @classmethod
+    def refuse(cls, request: dns.message.Message) -> bytes:
+        """Create serialized DNS reply indicating the request was refused."""
+        response = dns.message.make_response(request)
+        response.set_rcode(dns.rcode.REFUSED)
+        return response.to_wire()
+
+    @classmethod
     def process(cls, data) -> bytes:
         """Process DNS request."""
         if not getattr(cls, "_NODE_MANAGER", None):
             raise RuntimeError(f"{cls.__name__}: Node manager not set")
+        if not getattr(cls, "_ZONE", None):
+            raise RuntimeError(f"{cls.__name__}: Zone not set")
 
         request = dns.message.from_wire(data)
         if len(request.question) != 1:
-            log.error("Received DNS request with multiple questions: ignoring")
-            return request.to_wire()
+            log.warning("Refusing request with more than one question")
+            return cls.refuse(request)
 
         question = request.question[0]
-        qdomain = question.name.to_text(omit_final_dot=False)
-        qtype = dns.rdatatype.to_text(question.rdtype)
-        qclass = dns.rdataclass.to_text(question.rdclass)
-        log.debug(
-            "Received DNS request for domain=%s, class=%s, type=%s",
-            qdomain,
-            qclass,
-            qtype,
-        )
+        qdomain = question.name.to_text(omit_final_dot=False).lower()
+        if qdomain != cls._ZONE:
+            log.warning("Refusing request for unknown zone (name=%s)", qdomain)
+            return cls.refuse(request)
 
-        response = cls.create_response(request)
-        log.debug("Created DNS response (size=%d)", len(response))
-        return response
+        log.debug(
+            "Received DNS request for domain=%s (class=%s, type=%s)",
+            qdomain,
+            dns.rdatatype.to_text(question.rdtype),
+            dns.rdataclass.to_text(question.rdclass),
+        )
+        response_bytes = cls.create_response(request)
+        log.debug("Created DNS response (size=%d)", len(response_bytes))
+        return response_bytes
 
     @staticmethod
     def select_addresses(rdtype: dns.rdatatype.RdataType) -> List[Address]:
@@ -149,13 +167,13 @@ class DNSHandler:
 class DNSServer(threading.Thread):
     """DNS server."""
 
-    address: str
-    port: int
+    config: DNSConfig
     node_manager: NodeManager
 
     def __post_init__(self):
         super().__init__(name=self.__class__.__name__)
         DNSHandler.set_node_manager(self.node_manager)
+        DNSHandler.set_zone(self.config.zone)
 
     def run(self):
         """Start TCP and UDP DNS server threads."""
@@ -177,13 +195,18 @@ class DNSServer(threading.Thread):
 
     def run_server(
         self,
-        server_class: socketserver.BaseServer,
+        server_class: Callable,
         handler_class: socketserver.BaseRequestHandler,
     ):
         """Generic method to setup and run a DNS server, either UDP or TCP."""
-        server = server_class((self.address, self.port), handler_class)
+        server = server_class((self.config.address, self.config.port), handler_class)
         server_type = "UDP" if server_class == socketserver.UDPServer else "TCP"
-        log.info("Starting %s server on %s:%d", server_type, self.address, self.port)
+        log.info(
+            "Starting %s server on %s:%d",
+            server_type,
+            self.config.address,
+            self.config.port,
+        )
         server.serve_forever()
 
 


### PR DESCRIPTION
- [x] Reply with REFUSED to queries containing a domain for which the server is not authoritative
- [x] Create dedicated DNSConfig dataclass for command-line settings
- [x] Remove unnecessary CommandServer component